### PR TITLE
Allow static images without zooming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ dist
 # TernJS port file
 .tern-port
 
+# macOS
+.DS_Store
 
 /examples/assets
 /examples/*.mp4

--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -11,3 +11,5 @@ node ../cli.js --json subtitle.json5
 node ../cli.js --json transitionEasing.json5
 node ../cli.js --json transparentGradient.json5
 node ../cli.js --json commonFeatures.json5
+node ../cli.js --json kenBurns.json5
+node ../cli.js --json slideshow.json5

--- a/examples/slideshow.json5
+++ b/examples/slideshow.json5
@@ -1,0 +1,10 @@
+{
+  outPath: './slideshow.mp4',
+  defaults: {
+    transition: { name: 'fade' },
+  },
+  clips: [
+    { duration: 3, layers: [{ type: 'image', path: './assets/img2.jpg' }] },
+    { duration: 3, layers: [{ type: 'image', path: './assets/img3.jpg' }] },
+  ],
+}

--- a/sources/fabricFrameSource.js
+++ b/sources/fabricFrameSource.js
@@ -94,13 +94,24 @@ async function imageFrameSource({ verbose, params, width, height, canvas }) {
   if (blurredImg.height > blurredImg.width) blurredImg.scaleToWidth(width);
   else blurredImg.scaleToHeight(height);
 
+  const defaultScaleFactor = 1;
+  const scaleFns = {
+    in: (progress, zoomAmount = 0.1) => 1 + progress * zoomAmount,
+    out: (progress, zoomAmount = 0.1) => 1 + zoomAmount * (1 - progress),
+  };
 
   async function onRender(progress) {
-    const { zoomDirection = 'in', zoomAmount = 0.1 } = params;
+    const { zoomDirection, zoomAmount } = params;
 
     const img = getImg();
 
-    const scaleFactor = zoomDirection === 'in' ? (1 + progress * zoomAmount) : (1 + zoomAmount * (1 - progress));
+    let scaleFactor;
+    if (scaleFns[zoomDirection]) {
+      scaleFactor = scaleFns[zoomDirection](progress, zoomAmount);
+    } else {
+      scaleFactor = defaultScaleFactor;
+    }
+
     if (img.height > img.width) img.scaleToHeight(height * scaleFactor);
     else img.scaleToWidth(width * scaleFactor);
 


### PR DESCRIPTION
These changes make the Ken Burns effect optional. If a clip does not specify the `zoomDirection` parameter, it renders a static image instead.