### PR TITLE
Expose ffmpeg child-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Edit specs are JavaScript / JSON objects describing the whole edit operation wit
   enableFfmpegLog: false,
   verbose: false,
   fast: false,
+
+  onStart: (cmd) => console.log('Command:', cmd),
+  onProcessStart: (subprocess) => subprocess.stdout.pipe(process.stdout),
 }
 ```
 
@@ -156,6 +159,8 @@ Edit specs are JavaScript / JSON objects describing the whole edit operation wit
 | `clips[].transition` | | Specify transition at the **end** of this clip. See `defaults.transition` | `defaults.transition` | |
 | `clips[].layers[]` | | List of layers within the current clip that will be overlaid in their natural order (last layer on top) | | |
 | `clips[].layers[].type` | | Layer type, see below | | |
+| `onStart` | | Callback function, called before ffmpeg process start with command line as string argument | | |
+| `onProcessStart` | | Callback function, called after ffmpeg process start with subprocess argument | | |
 
 ### Transition types
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,14 @@ module.exports = async (config = {}) => {
 
     ffmpegPath = 'ffmpeg',
     ffprobePath = 'ffprobe',
+
+    onStart,
+    onProcessStart,
+    
   } = config;
+
+  assert(!onStart || typeof onStart === 'function', 'Callback onStart expected to be a function');
+  assert(!onProcessStart || typeof onProcessStart === 'function', 'Callback onProcessStart expected to be a function');
 
   const isGif = outPath.toLowerCase().endsWith('.gif');
 
@@ -314,6 +321,7 @@ module.exports = async (config = {}) => {
       ...outputArgs,
     ];
     if (verbose) console.log('ffmpeg', args.join(' '));
+    if (onStart) onStart(`ffmpeg ${args.join(' ')}`);
     return execa(ffmpegPath, args, { encoding: null, buffer: false, stdin: 'pipe', stdout: process.stdout, stderr: process.stderr });
   }
 
@@ -323,6 +331,7 @@ module.exports = async (config = {}) => {
 
   try {
     outProcess = startFfmpegWriterProcess();
+    if (onProcessStart) onProcessStart(outProcess);
     let outProcessError;
 
     // If we don't catch it here, the whole process will crash and we cannot process the error


### PR DESCRIPTION
The purpose of these changes is to expose ffmpeg process to higher level in order to log the ffmpeg command using application logging framework and in order to have better control on the child process for piping std in, out and err or to kill the process when needed.