### PR TITLE
Add fontPath and fixed typos in examples that use text

### DIFF
--- a/examples/audio-transition.json5
+++ b/examples/audio-transition.json5
@@ -5,6 +5,7 @@
   defaults: {
     duration: 3,
     transition: { duration: 1, name: 'directional' },
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
   },
   clips: [
     { layers: [

--- a/examples/audio1.json5
+++ b/examples/audio1.json5
@@ -4,6 +4,7 @@
   keepSourceAudio: true,
   defaults: {
     transition: null,
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
   },
   clips: [
     { duration: 0.5, layers: [{ type: 'video', path: './assets/lofoten.mp4', cutFrom: 0.4, cutTo: 2 }] },

--- a/examples/audio2.json5
+++ b/examples/audio2.json5
@@ -2,6 +2,9 @@
   // enableFfmpegLog: true,
   outPath: './audio2.mp4',
   width: 200, height: 200,
+  defaults: {
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
+  },
   clips: [
     { layers: [{ type: 'video', path: './assets/lofoten.mp4', cutFrom: 1, cutTo: 2 }] },
     { duration: 15, layers: { type: 'title-background', text: 'Audio track' } },

--- a/examples/audio3.json5
+++ b/examples/audio3.json5
@@ -1,6 +1,9 @@
 {
   outPath: './audio3.mp4',
   width: 200, height: 200,
+  defaults: {
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
+  },
   clips: [
     { layers: [{ type: 'video', path: './assets/lofoten.mp4', cutTo: 2 }, { type: 'title', text: 'Arbitrary audio' }] },
     { duration: 3, layers: [{ type: 'title-background', text: 'Voice starts in 1 sec' }, { type: 'detached-audio', path: './assets/Julen_ribas.m4a', mixVolume: 50, cutFrom: 2, start: 1 }] },

--- a/examples/audioLoop.json5
+++ b/examples/audioLoop.json5
@@ -5,6 +5,9 @@
   loopAudio: true,
   // Should properly cut off and not crash with EPIPE if loopAudio=false and audio duration is shorter than total duration
   // loopAudio: false,
+  defaults: {
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
+  },
   clips: [
     { duration: 10, layers: [{ type: 'title-background', text: 'Looping audio!' }] },
   ],

--- a/examples/losslesscut.json5
+++ b/examples/losslesscut.json5
@@ -7,7 +7,7 @@
   audioFilePath: './Believe - Roa [Vlog No Copyright Music]-qldyHxWPFUY.m4a',
   defaults: {
     transition: { name: 'crossZoom', duration: 1 },
-    layer: { fontPath: './Patua_One/PatuaOne-Regular.ttf' },
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
   },
   clips: [
     { duration: 3, layers: [{ type: 'title-background', text: 'LosslessCut', background: { type: 'linear-gradient' } }] },

--- a/examples/slideInText.json5
+++ b/examples/slideInText.json5
@@ -1,5 +1,8 @@
 {
   outPath: './slideInText.mp4',
+  defaults: {
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
+  },
   clips: [
     { duration: 3, layers: [
       { type: 'image', path: 'assets/img2.jpg' },

--- a/examples/videos2.json5
+++ b/examples/videos2.json5
@@ -6,6 +6,7 @@
     transition: {
       name: 'linearblur',
     },
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
   },
   clips: [
     { layers: [{ type: 'video', path: './assets/changi.mp4', cutFrom: 0, cutTo: 2 }, { type: 'title', text: 'Video 1' }] },

--- a/examples/visibleFromUntil.json5
+++ b/examples/visibleFromUntil.json5
@@ -1,6 +1,9 @@
 {
   // enableFfmpegLog: true,
   outPath: './visibleFromUntil.mp4',
+  defaults: {
+    layer: { fontPath: './assets/Patua_One/PatuaOne-Regular.ttf' },
+  },
   clips: [
     { duration: 2, layers: [
       { type: 'video', path: './assets/lofoten.mp4', cutFrom: 0.4, cutTo: 2 },


### PR DESCRIPTION
Hi!

Font was wonky in the audio examples, and a spent a good 30 minutes trying to sort out how fontpath worked before noticing other examples were already working fine :) This should now fixup any examples that use text layers. Thanks!