### PR TITLE
Ensure no generated artifacts get committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,8 @@ dist
 # TernJS port file
 .tern-port
 
-
+# Generated files and excluded assets repo
 /examples/assets
-/examples/*.mp4
-/examples/*.gif
+editly-tmp-*/
+*.mp4
+*.gif


### PR DESCRIPTION
Very small suggestions:

I was exploring getting docker and editly working (#96), and ended up with various mp4 and gif files in my repo (from cp in and out of container). Also was finding some `editly-tmp-*/` dirs around, though not sure when they were generated.

Slightly alterered gitignore to keep the workspace clean when things like this build up. Less room for mistakes and silly time-sinks perhaps :)

Merge as you please!