### PR TITLE
Add docker[-compose] support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM jrottenberg/ffmpeg:4.3.1-ubuntu1804
+
+WORKDIR /app
+
+# Ensures tzinfo doesn't ask for region info.
+ENV DEBIAN_FRONTEND noninteractive
+
+## INSTALL NODE VIA NVM
+
+RUN apt-get update && apt-get install -y \
+    dumb-init \
+    xvfb
+
+# Source: https://gist.github.com/remarkablemark/aacf14c29b3f01d6900d13137b21db3a
+# replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# update the repository sources list
+# and install dependencies
+RUN apt-get update \
+    && apt-get install -y curl \
+    && apt-get -y autoclean
+
+# nvm environment variables
+ENV NVM_VERSION 0.37.2
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 14.4.0
+
+# install nvm
+# https://github.com/creationix/nvm#install-script
+RUN mkdir -p $NVM_DIR \
+    && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v${NVM_VERSION}/install.sh | bash
+
+# install node and npm
+RUN source ${NVM_DIR}/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH ${NVM_DIR}/v${NODE_VERSION}/lib/node_modules
+ENV PATH      ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:$PATH
+
+# confirm installation
+RUN node -v
+RUN npm -v
+
+## INSTALL EDITLY
+
+# ## Install app dependencies
+COPY package.json /app/
+RUN npm install
+
+# Add app source
+COPY . /app
+
+# Ensure `editly` binary available in container
+RUN npm link
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "xvfb-run", "--server-args", "-screen 0 1280x1024x24 -ac"]
+CMD [ "editly" ]

--- a/README.md
+++ b/README.md
@@ -404,8 +404,8 @@ getting all the right versions of dependencies on your system.
 
 ```
 docker-compose up
-docker-compose run container bash -c "cd examples && editly audio1.json5 --out /outputs/audio1.mp4"
-docker cp container:/outputs/audio1.mp4
+docker-compose run editly bash -c "cd examples && editly audio1.json5 --out /outputs/audio1.mp4"
+docker cp editly:/outputs/audio1.mp4
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -397,6 +397,17 @@ See [position.json5](examples/position.json5)
 | `zoomDirection` | Zoom direction for Ken Burns effect: `in`, `out` or `null` to disable | | |
 | `zoomAmount` | Zoom amount for Ken Burns effect | `0.1` | |
 
+## Docker
+
+This should help you use editly as a containerized CLI, without worrying about
+getting all the right versions of dependencies on your system.
+
+```
+docker-compose up
+docker-compose run container bash -c "cd examples && editly audio1.json5 --out /outputs/audio1.mp4"
+docker cp container:/outputs/audio1.mp4
+```
+
 ## Troubleshooting
 
 - If you get `Error: The specified module could not be found.`, try: `npm un -g editly && npm i -g --build-from-source editly` (see [#15](https://github.com/mifi/editly/issues/15))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 
 services:
-  container:
+  editly:
     container_name: editly
     image: editly/editly:latest
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  container:
+    container_name: editly
+    image: editly/editly:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - "outputs:/outputs"
+
+volumes:
+  outputs:


### PR DESCRIPTION
Couldn't get editly working on my local OSX instance, so leaned on docker to get things going.

Added a simple container to persist some state between containers and make it easier to get artefacts out. Final image is quite large (~1GB), but could probably be made smaller. I tried to get it going with alpine linux at first (smaller footprint, likely around 300mb) but had some issues, so just cut my losses and got things working on ubuntu 18.04 first.

Someone might want to take a stab at getting this working on alpine, but I'd recommend it be another PR :)

Quick screenshare showing how this works (small typo, oops): https://recordit.co/SjnT1Oq40l

Same thing in GIF, but github might crop it short:

![screencast of using editly in docker](http://g.recordit.co/SjnT1Oq40l.gif)

This will be essential on the way to #93 