### PR TITLE
Updated docker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ getting all the right versions of dependencies on your system.
 ```
 docker-compose up
 docker-compose run editly bash -c "cd examples && editly audio1.json5 --out /outputs/audio1.mp4"
-docker cp editly:/outputs/audio1.mp4
+docker cp editly:/outputs/audio1.mp4 .
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
`docker cp` requires 2 arguments: docker cp [src] [destination folder]