### PR TITLE
Fix bug in videoFrameSource.js when the video frame buffer is too small (fixes #167)

### DIFF
--- a/sources/videoFrameSource.js
+++ b/sources/videoFrameSource.js
@@ -62,7 +62,8 @@ module.exports = async ({ width: canvasWidth, height: canvasHeight, channels, fr
 
   // TODO assert that we have read the correct amount of frames
 
-  const buf = Buffer.allocUnsafe(frameByteSize);
+  let buf = Buffer.allocUnsafe(frameByteSize);
+  const frameBuffer = Buffer.allocUnsafe(frameByteSize);
   let length = 0;
   // let inFrameCount = 0;
 
@@ -106,8 +107,27 @@ module.exports = async ({ width: canvasWidth, height: canvasHeight, channels, fr
     ended = true;
   });
 
+  // returns a frame from the buffer if available
+  function getNextFrame() {
+    if (length >= frameByteSize) {
+      // copy the frame
+      buf.copy(frameBuffer, 0, 0, frameByteSize);
+      // move remaining buffer content to the beginning
+      buf.copy(buf, 0, frameByteSize, length);
+      length -= frameByteSize;
+      return frameBuffer;
+    }
+    return null;
+  }
+
   async function readNextFrame(progress, canvas) {
     const rgba = await new Promise((resolve, reject) => {
+      const frame = getNextFrame();
+      if (frame) {
+        resolve(frame);
+        return;
+      }
+
       if (ended) {
         console.log(path, 'Tried to read next video frame after ffmpeg video stream ended');
         resolve();
@@ -128,28 +148,25 @@ module.exports = async ({ width: canvasWidth, height: canvasHeight, channels, fr
       }
 
       function handleChunk(chunk) {
-        // console.log('chunk', chunk.length);
-        const nCopied = length + chunk.length > frameByteSize ? frameByteSize - length : chunk.length;
+        const nCopied = Math.min(buf.length - length, chunk.length);
         chunk.copy(buf, length, 0, nCopied);
         length += nCopied;
-
-        if (length > frameByteSize) console.error('Video data overflow', length);
-
-        if (length >= frameByteSize) {
-          // console.log('Finished reading frame', inFrameCount, path);
-          const out = Buffer.from(buf);
-
-          const restLength = chunk.length - nCopied;
-          if (restLength > 0) {
-            // if (verbose) console.log('Left over data', nCopied, chunk.length, restLength);
-            chunk.slice(nCopied).copy(buf, 0);
-            length = restLength;
-          } else {
-            length = 0;
+        const out = getNextFrame();
+        const restLength = chunk.length - nCopied;
+        if (restLength > 0) {
+          if (verbose) console.log('Left over data', nCopied, chunk.length, restLength);
+          // make sure the buffer can store all chunk data
+          if (chunk.length > buf.length) {
+            if (verbose) console.log('resizing buffer', buf.length, chunk.length);
+            const newBuf = Buffer.allocUnsafe(chunk.length);
+            buf.copy(newBuf, 0, 0, length);
+            buf = newBuf;
           }
+          chunk.copy(buf, length, nCopied);
+          length += restLength;
+        }
 
-          // inFrameCount += 1;
-
+        if (out) {
           clearTimeout(timeout);
           cleanup();
           resolve(out);


### PR DESCRIPTION
Fix bug in videoFrameSource.js when the video frame buffer is too small to store the buffer received from ffmpeg.

I was trying to embed small video thumbnails in a video and got an exception in `videoFrameSource.js`. 

The problem was that the buffer can be very small then, eg 64x64 x 4 bytes (=16384 frame buffer length), but ffmpeg returns up to 64kb chunks.

This change fixes the case where ffmpeg returns such chunks which contain multiple frames.

