### PR TITLE
Improve the docker doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,14 @@ See [position.json5](examples/position.json5)
 This should help you use editly as a containerized CLI, without worrying about
 getting all the right versions of dependencies on your system.
 
-```
-docker-compose up
-docker-compose run editly bash -c "cd examples && editly audio1.json5 --out /outputs/audio1.mp4"
-docker cp editly:/outputs/audio1.mp4 .
+```bash
+$ git clone https://github.com/mifi/editly.git
+$ cd editly/examples
+$ git clone https://github.com/mifi/editly-assets.git assets
+$ cd ..
+$ docker-compose up
+$ docker-compose run editly bash -c "cd examples && editly audio1.json5 --out /outputs/audio1.mp4"
+$ docker cp editly:/outputs/audio1.mp4 .
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
The docker commands are useless without the assets trick presented in the examples doc [1].

These changes propose to append a snippet of doc to inform users to prepare their environments by cloning the rights repositories before starting to run the docker commands.

[1] https://github.com/mifi/editly/tree/master/examples