### PR TITLE
Rotation fix

### DIFF
--- a/parseConfig.js
+++ b/parseConfig.js
@@ -151,7 +151,7 @@ export default async function parseConfig({ defaults: defaultsIn = {}, clips, ar
 
         const inputDuration = cutTo - cutFrom;
 
-        const isRotated = rotation === 90 || rotation === 270;
+        const isRotated = [-90, 90, 270, -270].includes(rotation);
         const inputWidth = isRotated ? heightIn : widthIn;
         const inputHeight = isRotated ? widthIn : heightIn;
 

--- a/util.js
+++ b/util.js
@@ -34,7 +34,11 @@ export async function readVideoFileInfo(ffprobePath, p) {
 
   const duration = await readDuration(ffprobePath, p);
 
-  const rotation = stream.tags && stream.tags.rotate && parseInt(stream.tags.rotate, 10);
+  let rotation = stream.tags && stream.tags.rotate && parseInt(stream.tags.rotate, 10);
+  // If can't find rotation, try the new way
+  if(Number.isNaN(rotation) || rotation === undefined || rotation === null || rotation === false) {
+    rotation = stream.side_data_list && Array.isArray(stream.side_data_list) && stream.side_data_list[0] && stream.side_data_list[0].rotation && parseInt(stream.side_data_list[0].rotation, 10);
+  }
   return {
     // numFrames: parseInt(stream.nb_frames, 10),
     duration,

--- a/util.js
+++ b/util.js
@@ -34,11 +34,13 @@ export async function readVideoFileInfo(ffprobePath, p) {
 
   const duration = await readDuration(ffprobePath, p);
 
-  let rotation = stream.tags && stream.tags.rotate && parseInt(stream.tags.rotate, 10);
-  // If can't find rotation, try the new way
-  if(Number.isNaN(rotation) || rotation === undefined || rotation === null || rotation === false) {
-    rotation = stream.side_data_list && Array.isArray(stream.side_data_list) && stream.side_data_list[0] && stream.side_data_list[0].rotation && parseInt(stream.side_data_list[0].rotation, 10);
+  let rotation = parseInt(stream.tags && stream.tags.rotate, 10);
+
+  // If we can't find rotation, try side_data_list
+  if (Number.isNaN(rotation) && Array.isArray(stream.side_data_list) && stream.side_data_list[0] && stream.side_data_list[0].rotation) {
+    rotation = parseInt(stream.side_data_list[0].rotation, 10);
   }
+
   return {
     // numFrames: parseInt(stream.nb_frames, 10),
     duration,


### PR DESCRIPTION
The rotation information returned from ffprobe has been moved from `tags` to `side_data_list`. This update continues to check `tags` initially, then additionally checks `side_data_list`.

The update also allows for negative rotations when determining if a video has been rotated, i.e. it considers `-90` and `-270` to be rotated as well as `90` and `270`.