### PR TITLE
Adding fabricImagePostProcessing callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -281,6 +281,12 @@ declare namespace Editly {
 
 	}
 
+	interface VideoPostProcessingFunctionArgs {
+		canvas: Fabric.Canvas;
+		image: Fabric.Image;
+		progress: number;	
+	}
+
 	/**
 	 * For video layers, if parent `clip.duration` is specified, the video will be slowed/sped-up to match `clip.duration`.
 	 * If `cutFrom`/`cutTo` is set, the resulting segment (`cutTo`-`cutFrom`) will be slowed/sped-up to fit `clip.duration`.
@@ -372,6 +378,10 @@ declare namespace Editly {
 		 */
 		mixVolume?: number | string;
 
+		/**
+		 * Post-processing function after calling rgbaToFabricImage but before adding it to StaticCanvas.
+		 */
+		fabricImagePostProcessing?: (data: VideoPostProcessingFunctionArgs) => Promise<void>;
 	}
 
 	/**

--- a/sources/videoFrameSource.js
+++ b/sources/videoFrameSource.js
@@ -9,7 +9,7 @@ import {
 } from './fabric.js';
 
 export default async ({ width: canvasWidth, height: canvasHeight, channels, framerateStr, verbose, logTimes, ffmpegPath, ffprobePath, enableFfmpegLog, params }) => {
-  const { path, cutFrom, cutTo, resizeMode = 'contain-blur', speedFactor, inputWidth, inputHeight, width: requestedWidthRel, height: requestedHeightRel, left: leftRel = 0, top: topRel = 0, originX = 'left', originY = 'top' } = params;
+  const { path, cutFrom, cutTo, resizeMode = 'contain-blur', speedFactor, inputWidth, inputHeight, width: requestedWidthRel, height: requestedHeightRel, left: leftRel = 0, top: topRel = 0, originX = 'left', originY = 'top', fabricImagePostProcessing = null } = params;
 
   const requestedWidth = requestedWidthRel ? Math.round(requestedWidthRel * canvasWidth) : canvasWidth;
   const requestedHeight = requestedHeightRel ? Math.round(requestedHeightRel * canvasHeight) : canvasHeight;
@@ -225,6 +225,10 @@ export default async ({ width: canvasWidth, height: canvasHeight, channels, fram
         originY,
       });
       canvas.add(blurredImg);
+    }
+
+    if (fabricImagePostProcessing) {
+      fabricImagePostProcessing({ image: img, progress, canvas });
     }
 
     canvas.add(img);


### PR DESCRIPTION
Adding the fabricImagePostProcessing callback so users can modify the generated Fabric.Image right before being rendered.

For example this makes masking videos using ClipPath (from _fabric.js_ API) easy by adding a bit of code:

```js
await editly({
  outPath: './output.mp4', 
  clips: [{
    duration: 4, layers: [
      { type: 'video', path: './assets/lofoten.mp4', cutFrom: 0, cutTo: 4 },
      { 
        type: 'video', 
        path: './assets/hiking.mp4',
        cutFrom: 0, cutTo: 4, 
        resizeMode: 'cover',
        originX: 'center', originY: 'center',
        left: 0.5, top: 0.5, width: 0.5, height: 0.5,
        fabricImagePostProcessing: async ({image, progress, canvas})=> {
          const circleArgs = {
            radius:  Math.min(image.width, image.height) * 0.4,
            originX: 'center',
            originY: 'center',
            stroke: 'white',
            strokeWidth: 22,
          };
          image.setOptions({ clipPath: new fabric.Circle(circleArgs) });
          canvas.add(new fabric.Circle({
            ...circleArgs,
            left: image.getCenterPoint().x,
            top: image.getCenterPoint().y
          }));   
        }
      }
    ]}
  ]
});
```

https://user-images.githubusercontent.com/907138/214545896-ab420beb-bd50-4974-9bad-9657e4f0c849.mp4




