### PR TITLE
Add time to readNextFrame, pass it to fabricImagePostProcessing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -285,7 +285,8 @@ declare namespace Editly {
 		canvas: Fabric.Canvas;
 		image: Fabric.Image;
 		fabric: typeof Fabric,
-		progress: number;	
+		progress: number;
+		time: number;
 	}
 
 	/**

--- a/sources/frameSource.js
+++ b/sources/frameSource.js
@@ -75,7 +75,7 @@ export async function createFrameSource({ clip, clipIndex, width, height, channe
 
       if (shouldDrawLayer) {
         if (logTimes) console.time('frameSource.readNextFrame');
-        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, secondsProgress);
+        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, offsetTime);
         if (logTimes) console.timeEnd('frameSource.readNextFrame');
 
         // Frame sources can either render to the provided canvas and return nothing

--- a/sources/frameSource.js
+++ b/sources/frameSource.js
@@ -68,8 +68,8 @@ export async function createFrameSource({ clip, clipIndex, width, height, channe
     // eslint-disable-next-line no-restricted-syntax
     for (const { frameSource, layer } of layerFrameSources) {
       // console.log({ start: layer.start, stop: layer.stop, layerDuration: layer.layerDuration, time });
-      const secondsProgress = time - layer.start;
-      const offsetProgress = secondsProgress / layer.layerDuration;
+      const offsetTime = time - layer.start;
+      const offsetProgress = offsetTime / layer.layerDuration;
       // console.log({ offsetProgress });
       const shouldDrawLayer = offsetProgress >= 0 && offsetProgress <= 1;
 

--- a/sources/frameSource.js
+++ b/sources/frameSource.js
@@ -68,14 +68,14 @@ export async function createFrameSource({ clip, clipIndex, width, height, channe
     // eslint-disable-next-line no-restricted-syntax
     for (const { frameSource, layer } of layerFrameSources) {
       // console.log({ start: layer.start, stop: layer.stop, layerDuration: layer.layerDuration, time });
-      const timeProgress = (time - (layer.start));
-      const offsetProgress = timeProgress / layer.layerDuration;
+      const secondsProgress = time - layer.start;
+      const offsetProgress = secondsProgress / layer.layerDuration;
       // console.log({ offsetProgress });
       const shouldDrawLayer = offsetProgress >= 0 && offsetProgress <= 1;
 
       if (shouldDrawLayer) {
         if (logTimes) console.time('frameSource.readNextFrame');
-        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, timeProgress);
+        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, secondsProgress);
         if (logTimes) console.timeEnd('frameSource.readNextFrame');
 
         // Frame sources can either render to the provided canvas and return nothing

--- a/sources/frameSource.js
+++ b/sources/frameSource.js
@@ -68,13 +68,14 @@ export async function createFrameSource({ clip, clipIndex, width, height, channe
     // eslint-disable-next-line no-restricted-syntax
     for (const { frameSource, layer } of layerFrameSources) {
       // console.log({ start: layer.start, stop: layer.stop, layerDuration: layer.layerDuration, time });
-      const offsetProgress = (time - (layer.start)) / layer.layerDuration;
+      const timeProgress = (time - (layer.start));
+      const offsetProgress = timeProgress / layer.layerDuration;
       // console.log({ offsetProgress });
       const shouldDrawLayer = offsetProgress >= 0 && offsetProgress <= 1;
 
       if (shouldDrawLayer) {
         if (logTimes) console.time('frameSource.readNextFrame');
-        const rgba = await frameSource.readNextFrame(offsetProgress, canvas);
+        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, timeProgress);
         if (logTimes) console.timeEnd('frameSource.readNextFrame');
 
         // Frame sources can either render to the provided canvas and return nothing

--- a/sources/videoFrameSource.js
+++ b/sources/videoFrameSource.js
@@ -124,7 +124,7 @@ export default async ({ width: canvasWidth, height: canvasHeight, channels, fram
     return null;
   }
 
-  async function readNextFrame(progress, canvas) {
+  async function readNextFrame(progress, canvas, time) {
     const rgba = await new Promise((resolve, reject) => {
       const frame = getNextFrame();
       if (frame) {
@@ -229,7 +229,7 @@ export default async ({ width: canvasWidth, height: canvasHeight, channels, fram
     }
 
     if (fabricImagePostProcessing) {
-      fabricImagePostProcessing({ image: img, progress, fabric, canvas });
+      fabricImagePostProcessing({ image: img, progress, fabric, canvas, time });
     }
 
     canvas.add(img);


### PR DESCRIPTION
Add time to readNextFrame, pass it to fabricImagePostProcessing, the reasoning is that video editors do most operation in seconds so thats what most users are used to, so the API should have a way to work with seconds 

For example to add an animated circle that for the first 0.7 seconds of a video (regardless of the full length of the video) with this change we can do it like this:
```js
fabricImagePostProcessing: ({image, time}) => {
  const step = Math.min(time / 0.7, 1) || 0.001; // animation takes 0.7 seconds
  image.setOptions({
    clipPath: new fabric.Circle({radius: 25 * animatedValue}),
  });
}
```

If approved make sure to **squash** the commits on merge.