### PR TITLE
make GL optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ See [examples](https://github.com/mifi/editly/tree/master/examples)
 - (Linux) may require some extra steps. See [headless-gl](https://github.com/stackgl/headless-gl#system-dependencies).
 - **Editly is now ESM only**
 
+Note: While OpenGL is required for transitions, you may disable transitions and circumvent the need for OpenGL by setting all transition durations to zero. This is particularly useful on platforms that do not support installing Xvfb, like Google Cloud Functions.
+
 ## Installing
 
 `npm i -g editly`

--- a/glTransitions.js
+++ b/glTransitions.js
@@ -8,13 +8,24 @@ import createTexture from 'gl-texture2d';
 const { default: createTransition } = glTransition;
 
 export default ({ width, height, channels }) => {
-  const gl = GL(width, height);
+  let hasInitBeenCalled = false;
+  let gl;
 
-  if (!gl) {
-    throw new Error('gl returned null, this probably means that some dependencies are not installed. See README.');
+  function initGL() {
+    hasInitBeenCalled = true;
+
+    gl = GL(width, height);
+
+    if (!gl) {
+      throw new Error('gl returned null, this probably means that some dependencies are not installed. See README.');
+    }
   }
 
   function runTransitionOnFrame({ fromFrame, toFrame, progress, transitionName, transitionParams = {} }) {
+    if (!hasInitBeenCalled) {
+      initGL();
+    }
+
     function convertFrame(buf) {
       // @see https://github.com/stackgl/gl-texture2d/issues/16
       return ndarray(buf, [width, height, channels], [channels, width * channels, 1]);


### PR DESCRIPTION
There's no reason to mandate GL if transitions are disabled.

This pull request allows editly to be used on Google Cloud Functions, where xvfb cannot be installed.