### PR TITLE
rotation can be not only in the first element of side_data_list

### DIFF
--- a/util.js
+++ b/util.js
@@ -37,8 +37,12 @@ export async function readVideoFileInfo(ffprobePath, p) {
   let rotation = parseInt(stream.tags && stream.tags.rotate, 10);
 
   // If we can't find rotation, try side_data_list
-  if (Number.isNaN(rotation) && Array.isArray(stream.side_data_list) && stream.side_data_list[0] && stream.side_data_list[0].rotation) {
-    rotation = parseInt(stream.side_data_list[0].rotation, 10);
+  if (Number.isNaN(rotation) && Array.isArray(stream.side_data_list)) {
+    stream.side_data_list.forEach(element => {
+      if (element.rotation) {
+       rotation = parseInt(element.rotation, 10);
+      }
+    });
   }
 
   return {


### PR DESCRIPTION
Hello!
I've found that rotation on vertical HDR videos from my phone defined incorrectly. All videos without HDR don't have this issue.
![image](https://github.com/mifi/editly/assets/7704062/3a74e6e2-60d5-47c9-ad7c-0af24cc2d825)
My setup:
- dockerized editly from sources
- ffmpeg 6.0
- node v18.16.1 

ffprobe shows that HDR videos have several elements in side_data_list
```json
{
  "side_data_list":[
    {
      "side_data_type":"DOVI configuration record",
      "dv_version_major":1,
      "dv_version_minor":0,
      "dv_profile":8,
      "dv_level":5,
      "rpu_present_flag":1,
      "el_present_flag":0,
      "bl_present_flag":1,
      "dv_bl_signal_compatibility_id":4
    },
    {
      "side_data_type":"Display Matrix",
      "displaymatrix":"\n00000000:            0       65536           0\n00000001:       -65536           0           0\n00000002:     70778880           0  1073741824\n",
      "rotation":-90
    }
  ]
}
```
So I replaced [this](https://github.com/mifi/editly/blob/c77c302c58033101e27804db98000e64cd9ce716/util.js#L40C73-L40C134) with foreach cycle.

PS. But I still don't understand why [parseInt(stream.tags && stream.tags.rotate, 10)](https://github.com/mifi/editly/blob/c77c302c58033101e27804db98000e64cd9ce716/util.js#L37) always return NaN, when data is present in ffprobe json. 
