### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN apt-get update \
     && apt-get -y autoclean
 
 # nvm environment variables
-ENV NVM_VERSION 0.37.2
+ENV NVM_VERSION 0.39.7
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 14.4.0
+ENV NODE_VERSION 16.15.1
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
@@ -40,6 +40,9 @@ RUN source ${NVM_DIR}/nvm.sh \
 # add node and npm to path so the commands are available
 ENV NODE_PATH ${NVM_DIR}/v${NODE_VERSION}/lib/node_modules
 ENV PATH      ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:$PATH
+
+RUN echo "export LD_LIBRARY_PATH=/app/node_modules/canvas/build/Release/" >> /root/.bashrc
+ENV LD_LIBRARY_PATH /app/node_modules/canvas/build/Release/
 
 # confirm installation
 RUN node -v


### PR DESCRIPTION
Dockerfile did not work out of the box.  These were necessary changes to get editly running in Docker as far as I could tell. It's quite possible I was doing something wrong, but I thought it might save some you or someone else the trouble of having to debug this again

**ERROR 1**
First error is that you see this when you try to run editly:

 ERROR  Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'

Fix:
Put in a minimum NODE_VERSION  ( as documented here: https://stackoverflow.com/questions/69665780/error-err-unsupported-esm-url-scheme-only-file-and-data-urls-are-supported-by ) 


**Error 2**

internal/modules/cjs/loader.js:1250

  return process.dlopen(module, path.toNamespacedPath(filename));

Fix:
* Add LD_LIBRARY_PATH for canvas support, as documented here: https://github.com/mifi/editly/issues/141