### PR TITLE
Ignore video channel when combining arbitrary audio tracks

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -170,7 +170,7 @@ export default ({ ffmpegPath, ffprobePath, enableFfmpegLog, verbose, tmpDir }) =
       const cutToArg = (cutTo != null ? `:end=${cutTo}` : '');
       const apadArg = i > 0 ? ',apad' : ''; // Don't pad the first track (audio from video clips with correct duration)
 
-      return `[${i}]atrim=start=${cutFrom || 0}${cutToArg},adelay=delays=${Math.floor((start || 0) * 1000)}:all=1${apadArg}[a${i}]`;
+      return `[${i}:a]atrim=start=${cutFrom || 0}${cutToArg},adelay=delays=${Math.floor((start || 0) * 1000)}:all=1${apadArg}[a${i}]`;
     }).join(';');
 
     const volumeArg = outputVolume != null ? `,volume=${outputVolume}` : '';
@@ -185,6 +185,7 @@ export default ({ ffmpegPath, ffprobePath, enableFfmpegLog, verbose, tmpDir }) =
         '-stream_loop', (loop || 0),
         '-i', path,
       ]))),
+      '-vn',
       '-filter_complex', filterComplex,
       '-c:a', 'flac',
       '-y',


### PR DESCRIPTION
Given this spec, which is using an MP3 track that includes coverart metadata:
```json5
{
  allowRemoteRequests: true,
  width: 200,
  height: 200,
  audioFilePath: "https://sailboat.guide/storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6ImU2ZDQ2NGVmLTlmNWUtNGRhNi04NTA5LTZiMTNhMTg0OGVkMSIsInB1ciI6ImJsb2JfaWQifX0=--ebfaf46dad976f335f1054b993dcb86ba3f30d58/purrple-cat-meteorites.mp3",
  clips: [ { duration: 10, layers: [{ type: "title-background", text: "MP3 has coverart!" }] } ],
}

```

The following error is raised:


```
[png @ 0x150706870] Invalid PNG signature 0xFFD8FFE1214B4578.
[png @ 0x1507097c0] Invalid PNG signature 0xFFD8FFE1214B4578.
[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Error submitting packet to decoder: Invalid data found when processing input
[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Decode error rate 1 exceeds maximum 0.666667
[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Task finished with error code: -1145393733 (Error number -1145393733 occurred)
[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Terminating thread with return code -1145393733 (Error number -1145393733 occurred)
Cannot determine format of input 1:1 after EOF
[vf#0:1 @ 0x600001988120] Task finished with error code: -1094995529 (Invalid data found when processing input)
```

<details>
<summary>Full error</summary>
<pre>
{
  shortMessage: 'Command failed with exit code 69: ffmpeg -hide_banner -loglevel error -stream_loop 0 -i /Users/bkeepers/projects/editly/examples/editly-tmp-h7IgcI_b-cJl0kc3pgM9Y/clip0-audio.flac -stream_loop 0 -i https://sailboat.guide/storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6ImU2ZDQ2NGVmLTlmNWUtNGRhNi04NTA5LTZiMTNhMTg0OGVkMSIsInB1ciI6ImJsb2JfaWQifX0=--ebfaf46dad976f335f1054b993dcb86ba3f30d58/purrple-cat-meteorites.mp3 -filter_complex [0]atrim=start=0,adelay=delays=0:all=1[a0];[1]atrim=start=0,adelay=delays=0:all=1,apad[a1];[a0][a1]amix=inputs=2:duration=first:dropout_transition=0:weights=1 1 -c:a flac -y editly-tmp-h7IgcI_b-cJl0kc3pgM9Y/audio-mixed.flac',
  command: 'ffmpeg -hide_banner -loglevel error -stream_loop 0 -i /Users/bkeepers/projects/editly/examples/editly-tmp-h7IgcI_b-cJl0kc3pgM9Y/clip0-audio.flac -stream_loop 0 -i https://sailboat.guide/storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6ImU2ZDQ2NGVmLTlmNWUtNGRhNi04NTA5LTZiMTNhMTg0OGVkMSIsInB1ciI6ImJsb2JfaWQifX0=--ebfaf46dad976f335f1054b993dcb86ba3f30d58/purrple-cat-meteorites.mp3 -filter_complex [0]atrim=start=0,adelay=delays=0:all=1[a0];[1]atrim=start=0,adelay=delays=0:all=1,apad[a1];[a0][a1]amix=inputs=2:duration=first:dropout_transition=0:weights=1 1 -c:a flac -y editly-tmp-h7IgcI_b-cJl0kc3pgM9Y/audio-mixed.flac',
  escapedCommand: 'ffmpeg -hide_banner -loglevel error -stream_loop 0 -i "/Users/bkeepers/projects/editly/examples/editly-tmp-h7IgcI_b-cJl0kc3pgM9Y/clip0-audio.flac" -stream_loop 0 -i "https://sailboat.guide/storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6ImU2ZDQ2NGVmLTlmNWUtNGRhNi04NTA5LTZiMTNhMTg0OGVkMSIsInB1ciI6ImJsb2JfaWQifX0=--ebfaf46dad976f335f1054b993dcb86ba3f30d58/purrple-cat-meteorites.mp3" -filter_complex "[0]atrim=start=0,adelay=delays=0:all=1[a0];[1]atrim=start=0,adelay=delays=0:all=1,apad[a1];[a0][a1]amix=inputs=2:duration=first:dropout_transition=0:weights=1 1" "-c:a" flac -y "editly-tmp-h7IgcI_b-cJl0kc3pgM9Y/audio-mixed.flac"',
  exitCode: 69,
  signal: undefined,
  signalDescription: undefined,
  stdout: '',
  stderr: '[png @ 0x150706870] Invalid PNG signature 0xFFD8FFE1214B4578.\n' +
    '[png @ 0x1507097c0] Invalid PNG signature 0xFFD8FFE1214B4578.\n' +
    '[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Error submitting packet to decoder: Invalid data found when processing input\n' +
    '[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Decode error rate 1 exceeds maximum 0.666667\n' +
    '[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Task finished with error code: -1145393733 (Error number -1145393733 occurred)\n' +
    '[vist#1:1/png @ 0x150704b10] [dec:png @ 0x150709210] Terminating thread with return code -1145393733 (Error number -1145393733 occurred)\n' +
    'Cannot determine format of input 1:1 after EOF\n' +
    '[vf#0:1 @ 0x600001988120] Task finished with error code: -1094995529 (Invalid data found when processing input)\n' +
    '[vf#0:1 @ 0x600001988120] Terminating thread with return code -1094995529 (Invalid data found when processing input)\n' +
    '[vost#0:1/png @ 0x150707c80] Could not open encoder before EOF\n' +
    '[vost#0:1/png @ 0x150707c80] Task finished with error code: -22 (Invalid argument)\n' +
    '[vost#0:1/png @ 0x150707c80] Terminating thread with return code -22 (Invalid argument)\n' +
    '[out#0/flac @ 0x600001e84180] Nothing was written into output file, because at least one of its streams received no packets.',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
</pre>
</details>

This pull request updates the ffmpeg command to exclude video tracks when combining arbitrary audio tracks, which fixes the error.