### PR TITLE
chore: clean up ffmpeg/ffprobe config, update to execa@8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/ndarray": "^1.0.14",
     "canvas": "^2.11.2",
     "compare-versions": "^6.1.0",
-    "execa": "^6.1.0",
+    "execa": "^8.0.1",
     "fabric": "^6.5.4",
     "file-type": "^20.0.0",
     "file-url": "^4.0.0",

--- a/src/sources/frameSource.ts
+++ b/src/sources/frameSource.ts
@@ -52,15 +52,13 @@ const frameSources: Record<string, CreateFrameSource<any>> = {
 type FrameSourceOptions = DebugOptions & {
   clip: ProcessedClip;
   clipIndex: number;
-  ffmpegPath: string;
-  ffprobePath: string;
   width: number,
   height: number,
   channels: number,
   framerateStr: string,
 }
 
-export async function createFrameSource({ clip, clipIndex, width, height, channels, verbose, logTimes, ffmpegPath, ffprobePath, enableFfmpegLog, framerateStr }: FrameSourceOptions) {
+export async function createFrameSource({ clip, clipIndex, width, height, channels, verbose, logTimes, framerateStr }: FrameSourceOptions) {
   const { layers, duration } = clip;
 
   const visualLayers = layers.filter((layer) => layer.type !== 'audio');
@@ -80,7 +78,7 @@ export async function createFrameSource({ clip, clipIndex, width, height, channe
 
     assert(createFrameSourceFunc, `Invalid type ${type}`);
 
-    const frameSource = await createFrameSourceFunc({ ffmpegPath, ffprobePath, width, height, duration, channels, verbose, logTimes, enableFfmpegLog, framerateStr, params });
+    const frameSource = await createFrameSourceFunc({ width, height, duration, channels, verbose, logTimes, framerateStr, params });
     return { layer, frameSource };
   }, { concurrency: 1 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 
 import type * as Fabric from 'fabric/node';
 import type { Canvas } from "canvas"
+import type { FfmpegConfig } from './ffmpeg.js';
 
 /** Little utility */
 export type OptionalPromise<T> = Promise<T> | T;
@@ -935,12 +936,11 @@ export interface AudioNormalizationOptions {
 }
 
 export interface DebugOptions {
-  enableFfmpegLog?: boolean;
   verbose?: boolean;
   logTimes?: boolean;
 }
 
-export interface Config extends DebugOptions {
+export interface Config extends DebugOptions, FfmpegConfig {
   /**
    * Output path (`.mp4` or `.mkv`, can also be a `.gif`).
    */
@@ -1064,16 +1064,6 @@ export interface Config extends DebugOptions {
   /**
    * WARNING: Undocumented feature!
    */
-  ffmpegPath?: string;
-
-  /**
-   * WARNING: Undocumented feature!
-   */
-  ffprobePath?: string;
-
-  /**
-   * WARNING: Undocumented feature!
-   */
   keepTmp?: boolean;
 };
 
@@ -1093,20 +1083,6 @@ export interface RenderSingleFrameConfig extends Config {
 
 // Internal types
 
-export type Stream = {
-  codec_type: string;
-  codec_name: string;
-  r_frame_rate: string;
-  width?: number;
-  height?: number;
-  tags?: {
-    rotate: string;
-  };
-  side_data_list?: {
-    rotation: string;
-  }[];
-};
-
 export type Keyframe = {
   t: number;
   props: { [key: string]: number };
@@ -1118,8 +1094,6 @@ export interface FrameSource {
 }
 
 export type CreateFrameSourceOptions<T> = DebugOptions & {
-  ffmpegPath: string;
-  ffprobePath: string;
   width: number,
   height: number,
   duration: number,


### PR DESCRIPTION
Small refactoring to configure ffmpeg/ffprobe once when editly is loaded and not have to pass around the params everywhere. This also exposes `ffmpeg` and `ffprobe` functions to centralize where `execa` is being called so I can work on #304 without having to update multiple callsites.